### PR TITLE
Update workflows for build-resources v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    assignees:
+      - "kernelsam"
     cooldown:
-      default-days: 7
+      default-days: 21
+      exclude-patterns:
+        - "senzing-factory/*"
     directory: "/"
+    groups:
+      senzing-factory:
+        patterns:
+          - "senzing-factory/*"
     schedule:
       interval: "daily"

--- a/.github/workflows/add-labels-standardized.yaml
+++ b/.github/workflows/add-labels-standardized.yaml
@@ -14,14 +14,15 @@ jobs:
       issues: write
     secrets:
       ORG_MEMBERSHIP_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN }}
-      SENZING_MEMBERS: ${{ secrets.SENZING_MEMBERS }}
-    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v3
+      MEMBERS: ${{ secrets.SENZING_MEMBERS }}
+    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v4
 
   slack-notification:
     needs: [add-issue-labels]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-issue-labels.outputs.job-status }}
+      job-status: ${{ needs.add-issue-labels.result }}

--- a/.github/workflows/add-to-project-factory-dependabot.yaml
+++ b/.github/workflows/add-to-project-factory-dependabot.yaml
@@ -11,16 +11,17 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_PROJECT_FACTORY }}
 
   slack-notification:
     needs: [add-to-project-dependabot]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project-dependabot.outputs.job-status }}
+      job-status: ${{ needs.add-to-project-dependabot.result }}

--- a/.github/workflows/add-to-project-factory.yaml
+++ b/.github/workflows/add-to-project-factory.yaml
@@ -13,17 +13,18 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       project-number: ${{ vars.SENZING_PROJECT_FACTORY }}
       org: ${{ vars.SENZING_GITHUB_ACCOUNT_NAME }}
 
   slack-notification:
     needs: [add-to-project]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project.outputs.job-status }}
+      job-status: ${{ needs.add-to-project.result }}

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   review:
-    uses: senzing-factory/build-resources/.github/workflows/claude-pull-request-review.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/claude-pull-request-review.yaml@v4
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependabot-approve-and-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-merge.yaml
@@ -12,5 +12,5 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v3
+      CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v4

--- a/.github/workflows/link-issues-to-pr-post-merge.yaml
+++ b/.github/workflows/link-issues-to-pr-post-merge.yaml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/link-issues-to-pull-request-post-merge.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/link-issues-to-pull-request-post-merge.yaml@v4

--- a/.github/workflows/lint-repo.yaml
+++ b/.github/workflows/lint-repo.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: read
+      pull-requests: write
       statuses: write
-    uses: senzing-factory/build-resources/.github/workflows/linter.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/linter.yaml@v4

--- a/.github/workflows/move-dependabot-pr-to-done.yaml
+++ b/.github/workflows/move-dependabot-pr-to-done.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_PROJECT_FACTORY }}

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -10,4 +10,4 @@ jobs:
   spellcheck:
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/cspell.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/cspell.yaml@v4

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -19,6 +19,7 @@
     "ICLA",
     "irongut",
     "ISORT",
+    "kernelsam",
     "leonsteinhaeuser",
     "marocchino",
     "MYPY",


### PR DESCRIPTION
## Summary

  - Rename secret keys for build-resources v4 (`SENZING_MEMBERS` → `MEMBERS`, etc.)
  - Replace `.outputs.job-status` with `.result`
  - Bump `pull-requests` permission to `write` in lint-repo.yaml
  - Add `SLACK_CHANNEL` secret to slack notification callers
  - Bump all `@v3`/`@v2` build-resources references to `@v4`
  - Standardize dependabot config (assignees, cooldown, groups)
  - Add `kernelsam` to cspell dictionary